### PR TITLE
Support imports of multiple Categories from yaml files

### DIFF
--- a/categories/examples/test_multi.yaml
+++ b/categories/examples/test_multi.yaml
@@ -1,0 +1,44 @@
+---
+- name: TestCat1
+  time_sensitive: true
+  description: This is a category for testing for multi-category yaml import
+  tasks:
+  - name: task1
+    desc: desc for task1
+    time: 1
+  - name: task2
+    desc: desc for task2
+    time: 1
+  - name: task3
+    desc: desc for task3
+    time: 1
+  - name: task4
+    desc: desc for task4
+    time: 2
+  - name: task5
+    desc: desc for task5
+    time: 2
+  - name: task6
+    desc: desc for task6
+    time: 2
+  - name: task7
+    desc: desc for task7
+    time: 3
+  - name: task8
+    desc: desc for task8
+    time: 3
+  - name: task9
+    desc: desc for task9
+    time: 3
+
+
+- name: TestCat2
+  time_sensitive: false
+  description: This is another category for testing multi-category yaml import
+  tasks:
+  - name: task1
+    desc: desc for task1
+  - name: task2
+    desc: desc for task2
+  - name: task3
+    desc: desc for task3

--- a/screens/ImportExport.js
+++ b/screens/ImportExport.js
@@ -78,19 +78,20 @@ export default ({ navigation, route }) => {
 
         switch (type) {
           case 'json':
-            var parsedJson = JSON.parse(res);
-            if (Array.isArray(parsedJson)) {
-              parsedArray = JSON.parse(res);
-            } else {
-              parsedArray.push(JSON.parse(res));
-            }
+            var parsedFile = JSON.parse(res);
             break;
           case 'yaml':
-            parsedArray.push(YAML.load(res));
+            var parsedFile = YAML.load(res);
             break;
           case 'toml':
             parsedArray.push(TOML.parse(res));
             break;
+        }
+
+        if (Array.isArray(parsedFile)) {
+            parsedArray = parsedFile;
+        } else {
+            parsedArray.push(parsedFile);
         }
 
         addCategories(parsedArray);


### PR DESCRIPTION
The _js-yaml_ library loads yaml files to JSON structure. And the YAML format being a superset of JSON , almost anything possible in json should be possible for yaml too. YAML does support arrays at root level. 

This pull request enables support for the multi-category yaml by executing the json (array/object) handling logic after the yaml file has already been loaded to JSON.

---
p.s: Sweet concept! Thank you for giving it life as an app. Should help with my backlog. : )